### PR TITLE
Changing google auth version

### DIFF
--- a/.github/workflows/nosportugal-docker-build.yml
+++ b/.github/workflows/nosportugal-docker-build.yml
@@ -44,7 +44,7 @@ jobs:
             latest=auto
 
       - id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           token_format: "access_token"
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_ID }}


### PR DESCRIPTION
# 📑 Description

- Changing google auth version to `2` as the previous version is no longer supported.
